### PR TITLE
PYPI Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #ISAMBARD
 ###Intelligent System for Analysis, Model Building And Rational Design.
-#### Version 2016.2 (Nov 7, 2016), Woolfson Group, University of Bristol.
+#### Version 2016.2.1 (Nov 9, 2016), Woolfson Group, University of Bristol.
 [![CircleCI](https://circleci.com/gh/woolfson-group/isambard.svg?style=shield&circle-token=27387ac82a6d30c7bd6a72ce3214fa57677e9d87)](https://circleci.com/gh/woolfson-group/isambard)
 [![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg?maxAge=2592000)](https://gitter.im/woolfson-group/isambard?utm_source=share-link&utm_medium=link&utm_campaign=share-link)
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/woolfson-group/isambard/blob/master/LICENSE.md)

--- a/__init__.py
+++ b/__init__.py
@@ -1,5 +1,6 @@
 import inspect as _inspect
 import os as _os
+import subprocess as _subprocess
 import sys as _sys
 import pyximport; pyximport.install()
 
@@ -9,6 +10,9 @@ _cmd_folder = _os.path.realpath(_os.path.abspath(_os.path.split(_inspect.getfile
 _os.chdir(_cmd_folder)
 
 try:
+    if 'settings.json' not in _os.listdir(_cmd_folder):
+        print('No configuration file (settings.json) found in {}.\nRunning configure.py...\n'.format(_cmd_folder))
+        _subprocess.call(['python', 'configure.py'])
     from settings import global_settings
     import ampal
     import ampal.specifications as specifications

--- a/__init__.py
+++ b/__init__.py
@@ -28,4 +28,4 @@ try:
 finally:
     _os.chdir(_starting_dir)
 
-__version__ = "2016.2"
+__version__ = "2016.2.2"

--- a/ampal/assembly.py
+++ b/ampal/assembly.py
@@ -493,7 +493,11 @@ class Assembly(BaseAmpal):
         if total_seq_len != total_aa_len:
             raise ValueError('Total sequence length ({}) does not match total Polymer length ({}).'.format(
                 total_seq_len, total_aa_len))
-        packed_structure, scwrl_score = pack_sidechains(self.backbone.pdb, ''.join(sequences))
+        scwrl_out = pack_sidechains(self.backbone.pdb, ''.join(sequences))
+        if scwrl_out is None:
+            return
+        else:
+            packed_structure, scwrl_score = scwrl_out
         new_assembly = convert_pdb_to_ampal(packed_structure, path=False)
         self._molecules = new_assembly._molecules[:]
         self.assign_force_field(global_settings[u'buff'][u'force_field'])

--- a/ampal/protein.py
+++ b/ampal/protein.py
@@ -39,6 +39,8 @@ def find_ss_regions_polymer(polymer, ss):
         ss = [ss[:]]
     tag_key = 'secondary_structure'
     monomers = [x for x in polymer if tag_key in x.tags.keys()]
+    if len(monomers) == 0:
+        return Assembly()
     if (len(ss) == 1) and (all([m.tags[tag_key] == ss[0] for m in monomers])):
         return Assembly(polymer)
     previous_monomer = None
@@ -278,7 +280,11 @@ class Polypeptide(Polymer):
         if len(sequence) != len(polymer_bb):
             raise ValueError('Sequence length ({}) does not match Polymer length ({}).'.format(
                 len(sequence), len(polymer_bb)))
-        packed_structure, scwrl_score = pack_sidechains(self.backbone.pdb, sequence)
+        scwrl_out = pack_sidechains(self.backbone.pdb, sequence)
+        if scwrl_out is None:
+            return
+        else:
+            packed_structure, scwrl_score = scwrl_out
         new_assembly = convert_pdb_to_ampal(packed_structure, path=False)
         self._monomers = new_assembly[0]._monomers[:]
         self.tags['scwrl_score'] = scwrl_score
@@ -552,7 +558,10 @@ class Polypeptide(Polymer):
         """
         tagged = ['secondary_structure' in x.tags.keys() for x in self._monomers]
         if (not all(tagged)) or force:
-            dssp_ss_list = extract_all_ss_dssp(run_dssp(self.pdb, path=False), path=False)
+            dssp_out = run_dssp(self.pdb, path=False)
+            if dssp_out is None:
+                return
+            dssp_ss_list = extract_all_ss_dssp(dssp_out, path=False)
             for monomer, dssp_ss in zip(self._monomers, dssp_ss_list):
                 monomer.tags['secondary_structure'] = dssp_ss[1]
         return
@@ -597,7 +606,6 @@ class Polypeptide(Polymer):
             if tag_total:
                 self.tags['total_polymer_accessibility'] = total
 
-
     def tag_dssp_solvent_accessibility(self, force=False):
         """Tags each Monomer of the Polymer with its solvent accessibility as assigned by DSSP.
 
@@ -617,7 +625,10 @@ class Polypeptide(Polymer):
         """
         tagged = ['dssp_acc' in x.tags.keys() for x in self._monomers]
         if (not all(tagged)) or force:
-            dssp_acc_list = extract_solvent_accessibility_dssp(run_dssp(self.pdb, path=False), path=False)
+            dssp_out = run_dssp(self.pdb, path=False)
+            if dssp_out is None:
+                return
+            dssp_acc_list = extract_solvent_accessibility_dssp(dssp_out, path=False)
             for monomer, dssp_acc in zip(self._monomers, dssp_acc_list):
                 monomer.tags['dssp_acc'] = dssp_acc[-1]
         return

--- a/external_programs/dssp.py
+++ b/external_programs/dssp.py
@@ -1,8 +1,18 @@
 import os
 import subprocess
 import tempfile
+import warnings
 
 from settings import global_settings
+from tools.isambard_warnings import DependencyNotFoundWarning
+
+dssp_available = False
+try:
+    subprocess.check_output([global_settings['dssp']['path']], stderr=subprocess.DEVNULL)
+except subprocess.CalledProcessError:
+    dssp_available = True
+except FileNotFoundError:
+    dssp_available = False
 
 
 # TODO: make the format closer to SCWRL and BUDE
@@ -24,6 +34,12 @@ def run_dssp(pdb, path=True, outfile=None):
     dssp_out : str
         Std out from DSSP.
     """
+    if not dssp_available:
+        warning_string = ('DSSP not found, secondary structure has not been tagged.\n'
+                          'Check that the path to the DSSP binary in `settings.json` is correct.\n'
+                          'You might want to try rerunning `configure.py`')
+        warnings.warn(warning_string, DependencyNotFoundWarning, )
+        return
     if not path:
         # if statement added to be sure that encode is only called on string type.
         if type(pdb) == str:
@@ -45,7 +61,6 @@ def run_dssp(pdb, path=True, outfile=None):
     if outfile:
         with open(outfile, 'w') as outf:
             outf.write(dssp_out)
-
     return dssp_out
 
 

--- a/external_programs/scwrl.py
+++ b/external_programs/scwrl.py
@@ -2,8 +2,18 @@ import os
 import subprocess
 import tempfile
 import re
+import warnings
 
 from settings import global_settings
+from tools.isambard_warnings import DependencyNotFoundWarning
+
+scwrl_available = False
+try:
+    subprocess.check_output([global_settings['scwrl']['path']], stderr=subprocess.DEVNULL)
+except subprocess.CalledProcessError:
+    scwrl_available = True
+except FileNotFoundError:
+    scwrl_available = False
 
 
 def run_scwrl(pdb, sequence, path=True):
@@ -108,6 +118,12 @@ def parse_scwrl_out(scwrl_std_out, scwrl_pdb):
 
 def pack_sidechains(pdb, sequence, path=False):
     """Packs sidechains onto a given PDB file or string."""
+    if not scwrl_available:
+        warning_string = ('Scwrl not found, side chains have not been packed.\n'
+                          'Check that the path to the Scwrl binary in `settings.json` is correct.\n'
+                          'You might want to try rerunning `configure.py`')
+        warnings.warn(warning_string, DependencyNotFoundWarning)
+        return
     scwrl_std_out, scwrl_pdb = run_scwrl(pdb, sequence, path=path)
     return parse_scwrl_out(scwrl_std_out, scwrl_pdb)
 

--- a/tools/isambard_warnings.py
+++ b/tools/isambard_warnings.py
@@ -1,5 +1,9 @@
+import warnings
+
+
 class NoncanonicalWarning(RuntimeWarning):
     pass
+
 
 class NotParameterisedWarning(RuntimeWarning):
     pass
@@ -8,3 +12,8 @@ class NotParameterisedWarning(RuntimeWarning):
 class MalformedPDBWarning(RuntimeWarning):
     pass
 
+
+class DependencyNotFoundWarning(RuntimeWarning):
+    pass
+
+warnings.simplefilter('always', DependencyNotFoundWarning)


### PR DESCRIPTION
Allows ISAMBARD to run without dependencies, raising a `DependencyNotFoundWarning` rather than just raising a more cryptic error.