### PR TITLE
New BUFF structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #ISAMBARD
 ###Intelligent System for Analysis, Model Building And Rational Design.
-#### Version 2016.3 (Nov 11, 2016), Woolfson Group, University of Bristol.
+#### Version 2016.4 (Nov 22, 2016), Woolfson Group, University of Bristol.
 [![Documentation Status](https://readthedocs.org/projects/isambard/badge/?version=latest)](http://isambard.readthedocs.io/en/latest/?badge=latest)
 [![CircleCI](https://circleci.com/gh/woolfson-group/isambard.svg?style=shield&circle-token=27387ac82a6d30c7bd6a72ce3214fa57677e9d87)](https://circleci.com/gh/woolfson-group/isambard)
 [![codecov](https://codecov.io/gh/woolfson-group/isambard/branch/master/graph/badge.svg)](https://codecov.io/gh/woolfson-group/isambard)

--- a/isambard/__init__.py
+++ b/isambard/__init__.py
@@ -25,4 +25,4 @@ try:
 finally:
     _os.chdir(_starting_dir)
 
-__version__ = "2016.3"
+__version__ = "2016.4"

--- a/isambard/ampal/assembly.py
+++ b/isambard/ampal/assembly.py
@@ -5,7 +5,7 @@ from ampal.base_ampal import BaseAmpal, Polymer, find_atoms_within_distance
 from ampal.ligands import LigandGroup, Ligand
 from ampal.analyse_protein import sequence_molecular_weight, sequence_molar_extinction_280, \
     sequence_isoelectric_point
-from buff import score_ampal
+from buff import find_intra_ampal, find_inter_ampal, score_interactions
 from external_programs.scwrl import pack_sidechains
 from external_programs.naccess import run_naccess,extract_residue_accessibility
 from settings import global_settings
@@ -390,7 +390,7 @@ class Assembly(BaseAmpal):
                     fasta_str += '{0}\n'.format(seq_part)
         return fasta_str
 
-    def get_interaction_energy(self, assign_ff=True, ff=None, mol2=False, force_ff_assign=False, threshold=1.1):
+    def get_interaction_energy(self, assign_ff=True, ff=None, mol2=False, force_ff_assign=False):
         """Calculates the interaction energy of the AMPAL object.
 
         This method is assigned to the buff_interaction_energy property,
@@ -407,12 +407,10 @@ class Assembly(BaseAmpal):
         force_ff_assign: bool
             If true, the force field will be completely reassigned, ignoring the
             cached parameters.
-        threshold: float
-            Cutoff distance for assigning interactions that are covalent bonds.
 
         Returns
         -------
-        BUFF_score: BUFFScore
+        buff_score: BUFFScore
             A BUFFScore object with information about each of the interactions and
             the atoms involved.
         """
@@ -426,11 +424,13 @@ class Assembly(BaseAmpal):
                     raise AttributeError(
                         'The following molecule does not have a update_ff method:\n{}\n'
                         'If this is a custom molecule type it should inherit from BaseAmpal:'.format(molecule))
-        return score_ampal(self, ff, threshold=threshold)
+        interactions = find_inter_ampal(self, ff.distance_cutoff)
+        buff_score = score_interactions(interactions, ff)
+        return buff_score
 
     buff_interaction_energy = property(get_interaction_energy)
 
-    def get_internal_energy(self, assign_ff=True, ff=None, mol2=False, force_ff_assign=False, threshold=1.1):
+    def get_internal_energy(self, assign_ff=True, ff=None, mol2=False, force_ff_assign=False):
         """Calculates the internal energy of the AMPAL object.
 
         THIS METHOD REIMPLEMENTS THE BaseAmpal VERSION. This is so that
@@ -449,12 +449,10 @@ class Assembly(BaseAmpal):
         force_ff_assign: bool
             If true, the force field will be completely reassigned, ignoring the
             cached parameters.
-        threshold: float
-            Cutoff distance for assigning interactions that are covalent bonds.
 
         Returns
         -------
-        BUFF_score: BUFFScore
+        buff_score: BUFFScore
             A BUFFScore object with information about each of the interactions and
             the atoms involved.
         """
@@ -468,7 +466,9 @@ class Assembly(BaseAmpal):
                     raise AttributeError(
                         'The following molecule does not have a update_ff method:\n{}\n'
                         'If this is a custom molecule type it should inherit from BaseAmpal:'.format(molecule))
-        return score_ampal(self, ff, threshold=threshold, internal=True)
+        interactions = find_intra_ampal(self, ff.distance_cutoff)
+        buff_score = score_interactions(interactions, ff)
+        return buff_score
 
     buff_internal_energy = property(get_internal_energy)
 

--- a/isambard/ampal/base_ampal.py
+++ b/isambard/ampal/base_ampal.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy
 
-from buff import PyAtomData, score_ampal
+from buff import find_intra_ampal, score_interactions
 from ampal.ampal_databases import element_data
 from tools.isambard_warnings import NotParameterisedWarning
 from tools.geometry import distance, Quaternion, centre_of_mass, rmsd
@@ -204,7 +204,7 @@ class BaseAmpal(object):
             self.assign_force_field(ff, mol2=mol2)
         return
 
-    def get_internal_energy(self, assign_ff=True, ff=None, mol2=False, force_ff_assign=False, threshold=1.1):
+    def get_internal_energy(self, assign_ff=True, ff=None, mol2=False, force_ff_assign=False):
         """Calculates the internal energy of the AMPAL object.
 
         This method is assigned to the buff_internal_energy property,
@@ -221,8 +221,6 @@ class BaseAmpal(object):
         force_ff_assign: bool
             If true, the force field will be completely reassigned, ignoring the
             cached parameters.
-        threshold: float
-            Cutoff distance for assigning interactions that are covalent bonds.
 
         Returns
         -------
@@ -234,7 +232,9 @@ class BaseAmpal(object):
             ff = global_settings['buff']['force_field']
         if assign_ff:
             self.update_ff(ff, mol2=mol2, force_ff_assign=force_ff_assign)
-        return score_ampal(self, ff, threshold=threshold, internal=True)
+        interactions = find_intra_ampal(self, ff.distance_cutoff)
+        buff_score = score_interactions(interactions, ff)
+        return buff_score
 
     buff_internal_energy = property(get_internal_energy)
 

--- a/isambard/buff/__init__.py
+++ b/isambard/buff/__init__.py
@@ -1,2 +1,3 @@
 from buff.force_field import BuffForceField, force_fields
-from buff.calculate_energy import PyAtomData, find_buff_interactions, score_interactions, score_ampal
+from buff.calculate_energy import PyAtomData, score_interactions, get_within_ff_cutoff, find_inter_ampal, \
+    find_intra_ampal

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setuptools.setup(
     name='isambard',
     packages=setuptools.find_packages(),
     include_package_data=True,
-    version='2016.3',
+    version='2016.4',
     description='ISAMBARD: An open-source computational environment for biomolecular analysis, modelling and design',
     long_description=long_description,
     author='Woolfson Group, University of Bristol',

--- a/unit_tests/test_buff.py
+++ b/unit_tests/test_buff.py
@@ -4,6 +4,8 @@ import unittest
 import warnings
 
 import isambard
+from hypothesis import given, settings
+from hypothesis.strategies import integers
 
 warnings.filterwarnings("ignore")
 
@@ -59,19 +61,53 @@ class InteractionsTestCase(unittest.TestCase):
         self.pdb = isambard.ampal.convert_pdb_to_ampal(pdb_path)
         self.pdb.assign_force_field(self.ff)
 
-    def test_basic_interaction(self):
+    def test_basic_intra_format(self):
         """Tests that the interaction tuples are correctly formatted."""
-        buff_interactions = isambard.buff.calculate_energy.find_buff_interactions(self.topo, self.ff)
+        buff_interactions = isambard.buff.find_intra_ampal(self.topo, self.ff.distance_cutoff)
         for _ in range(100):
             a, b = random.choice(buff_interactions)
             self.assertTrue(type(a) is isambard.ampal.Atom)
             self.assertTrue(type(b) is isambard.ampal.Atom)
             self.assertTrue(a != b)
 
-    def test_inter_count_pdb(self):
-        """Tests that the number of interactions found in a pdb file."""
-        buff_interactions = isambard.buff.calculate_energy.find_buff_interactions(self.pdb, self.ff)
-        self.assertEqual(len(buff_interactions), 66546)  # Original scoring function
+    def test_basic_inter_format(self):
+        """Tests that the interaction tuples are correctly formatted."""
+        buff_interactions = isambard.buff.find_inter_ampal(self.topo, self.ff.distance_cutoff)
+        for _ in range(100):
+            a, b = random.choice(buff_interactions)
+            self.assertTrue(type(a) is isambard.ampal.Atom)
+            self.assertTrue(type(b) is isambard.ampal.Atom)
+            self.assertTrue(a != b)
+
+    @given(integers(min_value=1, max_value=50))
+    @settings(max_examples=20)
+    def test_intra_num_helix(self, n):
+        """Tests that the number of interactions found in a Helix backbone."""
+        ia_scaling = lambda x: (((x - 2) * (x - 1)) / 2) * 16 if x > 0.0 else 0.0
+        helix = isambard.specifications.Helix(n)
+        helix.assign_force_field(self.ff)
+        buff_interactions = isambard.buff.find_intra_ampal(helix, 1.52*(n+1))
+        self.assertEqual(len(buff_interactions), ia_scaling(n))
+
+    @given(integers(min_value=1, max_value=30), integers(min_value=2, max_value=5))
+    @settings(max_examples=10)
+    def test_inter_num_cc(self, n, hels):
+        """Tests that the number of interactions found between helices in a coiled coil."""
+        ia_scaling = lambda x, y: (((x ** 2) * (y - 1) * y) / 2) * 16 if x > 0.0 else 0.0
+        cc = isambard.specifications.CoiledCoil.from_parameters(hels, n, 7.0, 180.0, 18.0)
+        cc.assign_force_field(self.ff)
+        buff_interactions = isambard.buff.find_inter_ampal(cc, 1000)
+        self.assertEqual(len(buff_interactions), ia_scaling(n, hels))
+
+    def test_interaction_energy(self):
+        """Tests that the interaction energy of a reference structure."""
+        buff_score = self.pdb.get_interaction_energy(ff=self.ff)
+        self.assertAlmostEqual(buff_score.total_energy, -1005.41, places=2)  # Original scoring function
+
+    def test_internal_energy(self):
+        """Tests that the internal energy of a reference structure."""
+        buff_score = self.pdb[0].get_internal_energy(ff=self.ff)
+        self.assertAlmostEqual(buff_score.total_energy, -3722.49, places=2)  # Original scoring function
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The way that BUFF finds and scores interaction groups has changed significantly. The main aim was to generalise the process, with the aim of allowing interactions to be scored explicitly between two defined ampal objects. This is enabled through the `score_inter_ampal` function in the BUFF module.

New tests have been added to ensure that the number of interactions and the scores BUFF produces do not change unexpectedly.